### PR TITLE
Monitoring section removed in milestone template

### DIFF
--- a/.github/milestone_template.md
+++ b/.github/milestone_template.md
@@ -25,22 +25,6 @@
 - [ ] Issues created, with the rights labels and linked to this milestone
 - [ ] Issues assigned
 
-## Monitoring
-
-### Week 1
-
-[Detail this week's report]
-
-### Week 2
-
-[Detail this week's report]\
-[If this milestone's duration is less than 2 weeks, please delete this section]
-
-### Week 3
-
-[Detail this week's report]\
-[If this milestone's duration is less than 3 weeks, please delete this section]
-
 ## Final Report
 
 ### Checklist


### PR DESCRIPTION
# Description

Monitoring section removed in milestone template

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the needed labels
- [ ] I have linked this PR to an issue
- [ ] I have linked this PR to a milestone
- [x] I have linked this PR to a project
- [ ] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [x] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs